### PR TITLE
ignore env.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Include/
 # .github/ Who the fuck put that ? 
 pyvenv.cfg
 __pycache__/
+# we now have the committed code to load from secrets so this allows easy local override
+env.py


### PR DESCRIPTION
this file basically doesn't need any more changes so we should stop tracking it locally and allow devs to modify their copy without accidentally committing it